### PR TITLE
Remove alt text examples for now (they are a bit edge case-y)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Here's how to set yourself up to develop features for `skeleton-kit`.
+Here's how to get started developing features for `skeleton-kit`. Thanks for helping out!
 
 ## Installation
 
@@ -46,7 +46,7 @@ yarn prettier-check
 
 ## Deploying Storybook
 
-To deploy the Storybook build, first create a [GitHub token](https://github.com/settings/tokens) with all `repo` scopes. Run this from the `main` branch to deploy:
+To deploy the Storybook build, first create a [GitHub token](https://github.com/settings/tokens/new?scopes=repo) with all `repo` scopes. Run this from the `main` branch to deploy:
 
 ```
 GH_TOKEN=[your_token] yarn deploy-storybook

--- a/stories/Examples-2-Text.stories.tsx
+++ b/stories/Examples-2-Text.stories.tsx
@@ -1,11 +1,16 @@
-import { Meta } from "@storybook/react/types-6-0";
+// import { Meta } from "@storybook/react/types-6-0";
 
 import Text from "./Text";
 
 const Example = Text;
 export { Example };
 
-export default {
-  title: "Examples/Text",
-  component: Text,
-} as Meta;
+// This story is currently disabled for now.
+// It was originally meant to show how to work around the
+// edge case of slim line heights but that's an edge case
+// I'm not sure we need to worry about.
+
+// export default {
+//   title: "Examples/Text",
+//   component: Text,
+// } as Meta;

--- a/stories/GettingStarted/index.tsx
+++ b/stories/GettingStarted/index.tsx
@@ -22,7 +22,7 @@ import {
 } from "./styles";
 import ListsExample from "../Examples-0-Lists.stories";
 import ImagesExample from "../Examples-1-Images.stories";
-import TextExample from "../Examples-2-Text.stories";
+// import TextExample from "../Examples-2-Text.stories";
 
 const GettingStarted: React.FunctionComponent<Record<string, unknown>> = () => {
   const [isLoading, setLoadingState] = useState<boolean>(true);
@@ -117,12 +117,12 @@ const GettingStarted: React.FunctionComponent<Record<string, unknown>> = () => {
               <LinkTo kind={ImagesExample.title}>Images</LinkTo>
             </ExampleLink>
             <ExampleDef>Add square or circular image placeholders</ExampleDef>
-            <ExampleLink>
+            {/* <ExampleLink>
               <LinkTo kind={TextExample.title}>Text</LinkTo>
             </ExampleLink>
             <ExampleDef>
               Compare alternate strategies for replacing text
-            </ExampleDef>
+            </ExampleDef> */}
           </ExampleGrid>
           <H3>TODO</H3>
           <DashedUL>


### PR DESCRIPTION
I'm just going to hide the alt text examples right now because they were only needed to deal with slim line heights which is a bit of an edge case.