### PR TITLE
add deploy.yaml config for github action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: CICD
 on:
   push:
     branches:
@@ -28,3 +28,18 @@ jobs:
           CI: true
       - run: yarn lint
       - run: yarn prettier-check
+
+  deploy:
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Install deps
+        run: yarn install
+      - name: Deploy storybook
+        run: yarn deploy-storybook --ci
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Issue #5

Depends on a secret key in your account called `GH_ACCESS_TOKEN`. 

The only trick really was the `--ci` flag I passed to the deploy script.  Otherwise it doesn't use the right URL and fails with: 

```
Error: Exec code(128) on executing: git push --force --quiet https://github.com/mandric/skeleton-kit master:gh-pages
25
fatal: could not read Username for 'https://github.com': No such device or address
```
